### PR TITLE
Solved python3 incompatibility

### DIFF
--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -11,6 +11,9 @@ except ImportError:
 import peewee as pw
 import playhouse.migrate
 
+if sys.version_info >= (3,0):
+  raw_input = input
+
 
 DEBUG = False
 


### PR DESCRIPTION
raw_input is not defined in python3 but is used in the script. One solution to solve the problem and keep the code working with python2 and python3 is this.