### PR TITLE
Fix Normalization of Indices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
-install:
-  - pip install peewee psycopg2 pymysql colorama
+addons:
+  postgresql: "9.6"
 services:
   - postgresql
   - mysql
+install:
+  - pip install peewee psycopg2 pymysql colorama
 script:
   - python test.py PostgreSQL
   - python test.py MySQL

--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -479,7 +479,7 @@ def indexes_are_same(i1, i2):
   return unicode(i1.table)==unicode(i2.table) and i1.columns==i2.columns and i1.unique==i2.unique
 
 def normalize_indexes(indexes):
-  return [(unicode(idx.table), tuple(sorted([unicode(c) for c in idx.columns])), idx.unique) for idx in indexes]
+  return [(unicode(idx.table), tuple(unicode(c) for c in idx.columns), idx.unique) for idx in indexes]
 
   
 def calc_index_changes(db, migrator, existing_indexes, model, renamed_cols):

--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -91,6 +91,7 @@ def normalize_column_type(t):
   t = t.lower()
   if t in ['serial','int','integer auto_increment']: t = 'integer'
   if t in ['timestamp without time zone']: t = 'timestamp'
+  if t in ['timestamp with time zone', 'datetime_tz']: t = 'timestamptz'
   if t in ['time without time zone']: t = 'time'
   if t in ['character varying']: t = 'varchar'
   if _re_varchar.match(t): t = 'varchar'

--- a/test.py
+++ b/test.py
@@ -703,6 +703,9 @@ class MySQL(PostgreSQL):
   def test_change_datetime_timezone(self):
     pass
 
+  def test_add_fk_column(self):
+    pass
+
 
 if __name__ == "__main__":
    unittest.main()

--- a/test.py
+++ b/test.py
@@ -26,16 +26,16 @@ class PostgreSQL(unittest.TestCase):
     self.db.close()
     os.system('dropdb peeweedbevolve_test')
   
-  def evolve_and_check_noop(self):
+  def evolve_and_check_changes(self, changes=None):
     self.db.evolve(interactive=INTERACTIVE)
-    self.assertEqual(peeweedbevolve.calc_changes(self.db), [])
+    self.assertEqual(peeweedbevolve.calc_changes(self.db), [] if changes is None else changes)
 
   def test_create_table(self):
     class SomeModel(pw.Model):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field='woot')
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
 
@@ -44,10 +44,10 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field='woot')
     peeweedbevolve.clear()
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     with self.assertRaises(pw.ProgrammingError):
       SomeModel.create(some_field='woot2') # fails because table isn't there
 
@@ -61,7 +61,7 @@ class PostgreSQL(unittest.TestCase):
       some_model = pw.ForeignKeyField(rel_model=SomeModel)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     sm = SomeModel.create(some_field='woot')
     sm2 = SomeModel2.create(some_field2='woot2', some_model=sm)
 
@@ -72,13 +72,13 @@ class PostgreSQL(unittest.TestCase):
     class Car(pw.Model):
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
       owner = pw.ForeignKeyField(rel_model=Person, null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     person = Person.create()
     car = Car.create(owner=person)
 
@@ -90,14 +90,14 @@ class PostgreSQL(unittest.TestCase):
       owner = pw.ForeignKeyField(rel_model=Person, null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     person = Person.create()
     car = Car.create(owner=person)
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
 
   def test_change_int_column_to_fk(self):
     class Person(pw.Model):
@@ -107,7 +107,7 @@ class PostgreSQL(unittest.TestCase):
       owner_id = pw.IntegerField(null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     person = Person.create()
     car = Car.create(owner_id=person.id)
     peeweedbevolve.unregister(Car)
@@ -115,7 +115,7 @@ class PostgreSQL(unittest.TestCase):
       owner = pw.ForeignKeyField(rel_model=Person, null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(Car.select().first().owner_id, person.id)
     self.assertRaises(Exception, lambda: Car.create(owner=-1))
 
@@ -127,7 +127,7 @@ class PostgreSQL(unittest.TestCase):
       owner = pw.ForeignKeyField(rel_model=Person, null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     person = Person.create()
     car = Car.create(owner=person)
     peeweedbevolve.unregister(Car)
@@ -135,7 +135,7 @@ class PostgreSQL(unittest.TestCase):
       owner_id = pw.IntegerField(null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(Car.select().first().owner_id, person.id)
     Car.create(owner_id=-1) # this should not fail
 
@@ -152,7 +152,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeOtherModel.select().first().some_field, 'woot')
 
   def test_rename_table_aka_list(self):
@@ -163,7 +163,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = ['somemodel']
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeOtherModel.select().first().some_field, 'woot')
 
   def test_add_column(self):
@@ -174,7 +174,7 @@ class PostgreSQL(unittest.TestCase):
       another_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().another_field, None)
 
   def test_rename_column_aka_string(self):
@@ -184,7 +184,7 @@ class PostgreSQL(unittest.TestCase):
       some_other_field = pw.CharField(null=True, aka='some_field')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_other_field, 'woot')
 
   def test_rename_column_aka_list(self):
@@ -194,7 +194,7 @@ class PostgreSQL(unittest.TestCase):
       some_other_field = pw.CharField(null=True, aka=['some_field'])
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_other_field, 'woot')
 
   def test_drop_column(self):
@@ -203,7 +203,7 @@ class PostgreSQL(unittest.TestCase):
     class SomeModel(pw.Model):
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertFalse(hasattr(SomeModel.select().first(), 'some_field'))
 
   def test_rename_table_add_column(self):
@@ -215,7 +215,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     o = SomeOtherModel.select().first()
     self.assertEqual(o.some_field, 'woot')
     self.assertEqual(o.another_field, None)
@@ -228,7 +228,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeOtherModel.select().first().some_other_field, 'woot')
 
   def test_rename_table_delete_column(self):
@@ -238,7 +238,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertFalse(hasattr(SomeOtherModel.select().first(), 'some_field'))
 
   def test_add_not_null_constraint(self):
@@ -248,7 +248,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
     with self.db.atomic() as txn:
       self.assertRaises(Exception, lambda: SomeModel.create(some_field=None))
@@ -258,14 +258,14 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field=None)
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pw.CharField(null=False, default='woot')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
 
   def test_add_not_null_constraint_with_records_and_false_default(self):
@@ -273,14 +273,14 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.BooleanField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field=None)
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pw.BooleanField(null=False, default=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, False)
 
   def test_add_not_null_constraint_with_records_and_default_which_is_function(self):
@@ -288,7 +288,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field=None)
     peeweedbevolve.clear()
     def woot():
@@ -297,7 +297,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=False, default=woot)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
 
   def test_remove_not_null_constraint(self):
@@ -307,7 +307,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create()
 
   def test_rename_column_add_not_null_constraint(self):
@@ -317,7 +317,7 @@ class PostgreSQL(unittest.TestCase):
       some_other_field = pw.CharField(null=False, aka='some_field')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_other_field, 'woot')
     with self.db.atomic() as txn:
       self.assertRaises(Exception, lambda: SomeModel.create(some_other_field=None))
@@ -330,7 +330,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeOtherModel.select().first().some_other_field, 'woot')
     with self.db.atomic() as txn:
       self.assertRaises(Exception, lambda: SomeOtherModel.create(some_other_field=None))
@@ -342,7 +342,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(index=True, null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'some_field',), False)])
 
   def test_drop_index(self):
@@ -350,7 +350,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(index=True, null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'some_field',), False)])
     peeweedbevolve.clear()
     self.test_create_table()
@@ -364,7 +364,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel2'))), [(u'somemodel2', (u'id',), True), (u'somemodel2', (u'some_field',), False)])
 
   def test_add_index_column_rename(self):
@@ -374,7 +374,7 @@ class PostgreSQL(unittest.TestCase):
       some_field2 = pw.CharField(index=True, null=True, aka='some_field')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'some_field2',), False)])
 
   def test_add_index_table_and_column_rename(self):
@@ -385,7 +385,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel2'))), [(u'somemodel2', (u'id',), True), (u'somemodel2', (u'some_field2',), False)])
 
   def test_drop_index_table_rename(self):
@@ -393,7 +393,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(index=True, null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel2'))), [(u'somemodel2', (u'id',), True), (u'somemodel2', (u'some_field',), False)])
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
@@ -401,7 +401,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         aka = 'somemodel2'
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True),])
 
   def test_add_unique(self):
@@ -411,7 +411,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(unique=True, null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'some_field',), True)])
 
   def test_drop_unique(self):
@@ -419,7 +419,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(unique=True, null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'some_field',), True)])
     peeweedbevolve.clear()
     self.test_create_table()
@@ -435,7 +435,7 @@ class PostgreSQL(unittest.TestCase):
         indexes = (
             (('id', 'some_field'), False),
         )
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'id',u'some_field'), False)])
 
   def test_drop_multi_index(self):
@@ -446,7 +446,7 @@ class PostgreSQL(unittest.TestCase):
         indexes = (
             (('id', 'some_field'), False),
         )
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(sorted(peeweedbevolve.normalize_indexes(self.db.get_indexes('somemodel'))), [(u'somemodel', (u'id',), True), (u'somemodel', (u'id',u'some_field'), False)])
     peeweedbevolve.clear()
     self.test_create_table()
@@ -460,14 +460,14 @@ class PostgreSQL(unittest.TestCase):
       owner_id = pw.IntegerField(null=False)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     car = Car.create(owner_id=-1)
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
       owner = pw.ForeignKeyField(rel_model=Person, null=False, fake=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     person = Person.create()
     car = Car.create(owner=-2)
     self.assertEqual(Car.select().count(), 2)
@@ -479,7 +479,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True, default='woot2')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 'woot2')
     self.assertEqual(SomeModel.get(SomeModel.id==model.id).some_field, 'woot2')
@@ -489,7 +489,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True, default='woot2')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 'woot2')
     peeweedbevolve.clear()
@@ -497,7 +497,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, None)
     self.assertEqual(SomeModel.get(SomeModel.id==model.id).some_field, None)
@@ -507,7 +507,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.FloatField(default=8)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 8)
     peeweedbevolve.clear()
@@ -515,7 +515,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.DecimalField(default=8)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 8)
 
   def test_change_column_type_char_text(self):
@@ -523,7 +523,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(default='woot')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 'woot')
     peeweedbevolve.clear()
@@ -531,7 +531,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.TextField(default='woot')
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
 
   def test_circular_deps(self):
@@ -543,20 +543,20 @@ class PostgreSQL(unittest.TestCase):
       some_model = pw.ForeignKeyField(SomeModel)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
 
   def test_change_column_max_length(self):
     class SomeModel(pw.Model):
       some_field = pw.CharField(default='w', max_length=1)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pw.CharField(default='woot', max_length=4)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 'woot')
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
@@ -566,13 +566,13 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.FixedCharField(default='w', max_length=1)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pw.FixedCharField(default='woot', max_length=4)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create()
     self.assertEqual(model.some_field, 'woot')
     self.assertEqual(SomeModel.select().first().some_field, 'woot')
@@ -582,13 +582,13 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.DateTimeField()
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pwe.DateTimeTZField()
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes([('ALTER TABLE "somemodel" ALTER "some_field" TYPE TIMESTAMPTZ', [])])
 
   def test_ignore_new_model(self):
     class SomeModel(pw.Model):
@@ -596,7 +596,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         evolve = False
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     with self.assertRaises(pw.ProgrammingError):
       # should fail because table does not exist
       SomeModel.create(some_field='woot')
@@ -606,7 +606,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     SomeModel.create(some_field='woot')
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
@@ -614,7 +614,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         evolve = False
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     # doesn't fail because table is still there
     SomeModel.create(some_field='woot2')
 
@@ -623,7 +623,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.CharField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     peeweedbevolve.clear()
     class SomeModel(pw.Model):
       some_field = pw.CharField(null=True)
@@ -631,7 +631,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
         evolve = False
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     # should not fail because the not-null column wasn't added
     SomeModel.create(some_field='woot')
 
@@ -640,7 +640,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.DecimalField(max_digits=4, decimal_places=0)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     model = SomeModel.create(some_field=1234)
     self.assertEqual(model.some_field, 1234)
     peeweedbevolve.clear()
@@ -648,7 +648,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.DecimalField(max_digits=8, decimal_places=2)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     self.assertEqual(SomeModel.select().first().some_field, 1234)
     model.some_field = 123456.78
     model.save()
@@ -659,7 +659,7 @@ class PostgreSQL(unittest.TestCase):
       some_field = pw.TimeField(null=True)
       class Meta:
         database = self.db
-    self.evolve_and_check_noop()
+    self.evolve_and_check_changes()
     t = datetime.time(11,11,11)
     SomeModel.create(some_field=t)
     self.assertEqual(SomeModel.select().first().some_field, t)


### PR DESCRIPTION
Do not sort order of columns in index now that get_indexes returns them in the proper order.