### PR TITLE
Support for Peewee 3.7

### DIFF
--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -17,9 +17,14 @@ except ImportError:
 
 if sys.version_info >= (3,0):
   raw_input = input
+  from collections.abc import Iterable
+else:
+  from collections import Iterable
+
 
 
 DEBUG = False
+PW3 = not hasattr(pw, 'Clause')
 
 # peewee doesn't do defaults in the database - doh!
 DIFF_DEFAULTS = False
@@ -33,25 +38,276 @@ except NameError:
   unicode = lambda s: str(s)
 
 
+###################
+# Peewee 2 Shims
+###################
+
+if PW3:
+  def extract_query_from_migration(migration):
+    if isinstance(migration, Iterable):
+      # Postgrsql has context first, MySql has context last :(
+      ctx = next(obj for obj in migration if isinstance(obj, pw.Context))
+    else:
+      ctx = migration
+    return [ctx.query()]
+
+  def _table_name(model):
+    return model._meta.table_name
+
+  def _column_name(field):
+    return field.column_name
+
+  def _field_type(field):
+    return field.field_type
+
+  def _is_foreign_key(field):
+    return hasattr(field, 'rel_model')
+
+  def create_table(model):
+    manager = pw.SchemaManager(model)
+    ctx = manager._create_table()
+    return [(''.join(ctx._sql), ctx._values)]
+
+  def rename_table(migrator, before, after):
+    migration = migrator.rename_table(before, after, with_context=True)
+    return extract_query_from_migration(migration)
+
+  def drop_table(migrator, name):
+    migration = migrator.make_context().literal('DROP TABLE ').sql(pw.Entity(name))
+    return extract_query_from_migration(migration)
+
+  def create_index(model, fields, unique):
+    manager = pw.SchemaManager(model)
+    ctx = manager._create_index(pw.ModelIndex(model, fields, unique=unique))
+    return [(''.join(ctx._sql), ctx._values)]
+
+  def drop_index(migrator, model, index):
+    migration = migrator.make_context().literal('DROP INDEX ').sql(pw.Entity(index.name))
+    if is_mysql(model._meta.database):
+      migration = migration.literal(' ON ').sql(pw.Entity(_table_name(model)))
+    return extract_query_from_migration(migration)
+
+  def create_foreign_key(field):
+    manager = pw.SchemaManager(field.model)
+    ctx = manager._create_foreign_key(field)
+    return [(''.join(ctx._sql), ctx._values)]
+
+  def drop_foreign_key(db, migrator, table_name, fk_name):
+    drop_stmt = ' DROP FOREIGN KEY ' if is_mysql(db) else ' DROP CONSTRAINT '
+    migration = migrator._alter_table(migrator.make_context(), table_name).literal(drop_stmt).sql(pw.Entity(fk_name))
+    return extract_query_from_migration(migration)
+
+  def drop_default(db, migrator, table_name, column_name, field):
+    migration = migrator._alter_column(ctx, table_name, column_name).literal('DROP DEFAULT')
+    return extract_query_from_migration(migration)
+
+  def set_default(db, migrator, table_name, column_name, field):
+    migration = migrator.apply_default(table_name, column_name, field, with_context=True)
+    return extract_query_from_migration(migration)
+
+  def alter_add_column(db, migrator, ntn, column_name, field):
+    migration = migrator.alter_add_column(ntn, column_name, field, with_context=True)
+    to_run = extract_query_from_migration(migration)
+    if is_mysql(db) and _is_foreign_key(field):
+      to_run += create_foreign_key(field)
+    return to_run
+
+  def drop_not_null(migrator, ntn, defined_col):
+    migration = migrator.drop_not_null(ntn, defined_col.name, with_context=True)
+    return extract_query_from_migration(migration)
+
+  def rename_column(db, migrator, table, ocn, ncn, field):
+    if is_mysql(db):
+      ctx = migrator.make_context()
+      migration = migrator._alter_table(ctx, table).literal(' CHANGE ').sql(pw.Entity(ocn)).literal(' ').sql(field.ddl(ctx))
+    else:
+      migration = migrator.rename_column(table, ocn, ncn, with_context=True)
+    return extract_query_from_migration(migration)
+
+  def drop_column(db, migrator, table, column_name):
+    migration = migrator.drop_column(table, column_name, cascade=False, with_context=True)
+    return extract_query_from_migration(migration)
+
+  def change_column_type(db, migrator, table_name, column_name, field):
+    column_type = _field_type(field)
+    ctx = migrator.make_context()
+    if is_postgres(db):
+      migration = migrator._alter_column(ctx, table_name, column_name).literal(' TYPE ').sql(field.ddl_datatype(ctx))
+    elif is_mysql(db):
+      migration = migrator._alter_table(ctx, table_name).literal(' MODIFY COLUMN ').sql(field.ddl(ctx))
+    else:
+      raise Exception('how do i change a column type for %s?' % db)
+
+    return extract_query_from_migration(migration)
+
+  def add_not_null(db, migrator, table, column_name, field):
+    cmds = []
+    if field.default is not None:
+      cmds += set_default(db, migrator, table, column_name, field)
+    if is_mysql(db):
+      ctx = migrator.make_context()
+      cmds.append(migrator._alter_table(ctx, table).literal(' MODIFY COLUMN ').sql(field.ddl(ctx)).query())
+    else:
+      migration = migrator.add_not_null(table, column_name, with_context=True)
+      cmds += extract_query_from_migration(migration)
+    return cmds
+
+  def indexes_on_model(model):
+    return [
+      pw.IndexMetadata('', '', [_column_name(f) for f in idx._expressions], idx._unique, _table_name(model))
+      for idx in model._meta.fields_to_index()
+    ]
+
+else:
+  def normalize_op_to_clause(db, migrator, op):
+    if isinstance(op, pw.Clause): return op
+    playhouse.migrate
+    kwargs = op.kwargs.copy()
+    kwargs['generate'] = True
+    ret = getattr(migrator, op.method)(*op.args, **kwargs)
+    return ret
+
+  def _table_name(cls):
+    return cls._meta.db_table
+
+  def _column_name(cls):
+    return cls.db_column
+
+  def _field_type(cls):
+    compiler = field.database.compiler()
+    return compiler.get_column_type(field.get_db_field())
+
+  def _is_foreign_key(field):
+    return isinstance(field, pw.ForeignKeyField)
+
+  def create_table(cls):
+    compiler = cls.database.compiler()
+    return ompiler.parse_node(compiler.create_table(cls))
+
+  def rename_table(migrator, before, after, generate=True):
+    ops = migrator.rename_table(before, after, generate)
+    if not hasattr(ops, '__iter__'): ops = [ops] # sometimes pw return arrays, sometimes not
+    return [qc.parse_node(op) for op in ops]
+
+  def drop_table(migrator, tbl):
+    compiler = field.database.compiler()
+    return compiler.parse_node(pw.Clause(pw.SQL('DROP TABLE'), pw.Entity(tbl)))
+
+  def create_index(model, fields, name):
+    compiler = model.database.compiler()
+    return qc.create_index(model, fields, name)
+
+  def drop_index(migrator, model, index):
+    compiler = model.database.compiler()
+    return qc.drop_index(model, fields, name)
+
+  def create_foreign_key(field):
+    compiler = field.database.compiler()
+    return compiler.parse_node(compiler.create_foreign_key(field.model_class, field))
+
+  def drop_foreign_key(db, migrator, table_name, fk_name):
+    drop_stmt = 'drop foreign key' if is_mysql(db) else 'DROP CONSTRAINT'
+    op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL(drop_stmt), pw.Entity(fk_name))
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
+
+  def drop_default(db, migrator, table_name, column_name, field):
+    op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER COLUMN'), pw.Entity(column_name), pw.SQL('DROP DEFAULT'))
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
+
+  def set_default(db, migrator, table_name, column_name, field):
+    default = field.default
+    if callable(default): default = default()
+    param = pw.Param(field.db_value(default))
+    op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER COLUMN'), pw.Entity(column_name), pw.SQL('SET DEFAULT'), param)
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
+
+  def alter_add_column(db, migrator, ntn, column_name, field):
+    operation = migrator.alter_add_column(ntn, column_name, field, generate=True)
+    to_run = [qc.parse_node(operation)]
+    if is_mysql(db) and _is_foreign_key(field):
+      to_run += create_foreign_key(field)
+    return to_run
+
+  def drop_not_null(migrator, ntn, defined_col):
+    qc = migrator.database.compiler()
+    op = migrator.drop_not_null(ntn, defined_col.name, generate=True)
+    return [qc.parse_node(op)]
+
+  def rename_column(db, migrator, ntn, ocn, ncn, field):
+    if is_mysql(db):
+      junk = pw.Clause(
+        pw.SQL('ALTER TABLE'), pw.Entity(ntn), pw.SQL('CHANGE'), pw.Entity(ocn), qc.field_definition(field)
+      )
+    else:
+      junk = migrator.rename_column(ntn, ocn, ncn, generate=True)
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk)
+
+  def drop_column(db, migrator, ntn, column_name):
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, migrator.drop_column(ntn, column_name, generate=True, cascade=False))
+
+  def change_column_type(db, migrator, table_name, column_name, field):
+    column_type = _field_type(field)
+    if is_postgres(db):
+      op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER'), field.as_entity(), pw.SQL('TYPE'), field.__ddl_column__(column_type))
+    elif is_mysql(db):
+      op = pw.Clause(*[pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('MODIFY')] + field.__ddl__(column_type))
+    else:
+      raise Exception('how do i change a column type for %s?' % db)
+    return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
+
+  def normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk):
+    # sometimes a clause, sometimes an operation, sometimes a list mixed with clauses and operations
+    # turn it into a list of (sql,params) tuples
+    if not hasattr(junk, '__iter__'):
+      junk = [junk]
+    junk = [normalize_op_to_clause(db, migrator, o) for o in junk]
+    junk = [qc.parse_node(clause) for clause in junk]
+    return junk
+
+  def add_not_null(db, migrator, table, column_name, field):
+    cmds = []
+    if field.default is not None:
+      # if default is a function, turn it into a value
+      # this won't work on columns requiring uniquiness, like UUIDs
+      # as all columns will share the same called value
+      default = field.default() if hasattr(field.default, '__call__') else field.default
+      op = pw.Clause(pw.SQL('UPDATE'), pw.Entity(table), pw.SQL('SET'), field.as_entity(), pw.SQL('='), default, pw.SQL('WHERE'), field.as_entity(), pw.SQL('IS NULL'))
+      cmds.append(qc.parse_node(op))
+    if is_postgres(db) or is_sqlite(db):
+      junk = migrator.add_not_null(table, column_name, generate=True)
+      cmds += normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk)
+      return cmds
+    elif is_mysql(db):
+      op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table), pw.SQL('MODIFY'), qc.field_definition(field))
+      cmds.append(qc.parse_node(op))
+      return cmds
+    raise Exception('how do i add a not null for %s?' % db)
+
+  def indexes_on_model(model):
+    return [pw.IndexMetadata('', '', [_column_name(f)], f.unique, _table_name(model)) for f in model._fields_to_index]
+
+####
+
 def mark_fks_as_deferred(table_names):
   add_fks = []
-  table_names_to_models = {cls._meta.db_table:cls for cls in all_models.keys() if cls._meta.db_table in table_names}
+  table_names_to_models = {_table_name(cls): cls for cls in all_models.keys() if _table_name(cls) in table_names}
+
   for model in table_names_to_models.values():
     for field in model._meta.sorted_fields:
-      if isinstance(field, pw.ForeignKeyField):
+      if _is_foreign_key(field):
         add_fks.append(field)
         if not field.deferred:
           field.__pwdbev__not_deferred = True
           field.deferred = True
   return add_fks
-  
+
 def calc_table_changes(existing_tables, ignore_tables=None):
   if ignore_tables:
     ignore_tables = set(ignore_tables) | globals()['ignore_tables']
   else:
     ignore_tables = globals()['ignore_tables']
   existing_tables = set(existing_tables)
-  table_names_to_models = {unicode(cls._meta.db_table):cls for cls in all_models.keys()}
+  table_names_to_models = {unicode(_table_name(cls)):cls for cls in all_models.keys()}
   defined_tables = set(table_names_to_models.keys())
   adds = defined_tables - existing_tables - ignore_tables
   deletes = existing_tables - defined_tables - ignore_tables
@@ -71,7 +327,7 @@ def calc_table_changes(existing_tables, ignore_tables=None):
           break
   add_fks = mark_fks_as_deferred(adds)
   return adds, add_fks, deletes, renames
-  
+
 def is_postgres(db):
   return isinstance(db, pw.PostgresqlDatabase)
 
@@ -93,21 +349,17 @@ def auto_detect_migrator(db):
 _re_varchar = re.compile('^varchar[(]\\d+[)]$')
 def normalize_column_type(t):
   t = t.lower()
-  if t in ['serial','int','integer auto_increment']: t = 'integer'
-  if t in ['timestamp without time zone']: t = 'timestamp'
+  if t in ['serial', 'int', 'integer auto_increment', 'auto']: t = 'integer'
+  if t in ['timestamp without time zone', 'datetime']: t = 'timestamp'
   if t in ['timestamp with time zone', 'datetime_tz']: t = 'timestamptz'
   if t in ['time without time zone']: t = 'time'
   if t in ['character varying']: t = 'varchar'
   if _re_varchar.match(t): t = 'varchar'
-  if t in ['decimal','real']: t = 'numeric'
+  if t in ['decimal', 'real', 'float']: t = 'numeric'
+  if t in ['boolean']: t = 'bool'
   return unicode(t)
-  
-def normalize_field_type(field, qc):
-#  t = field.get_column_type()
-  t = qc.get_column_type(field.get_db_field())
-  return normalize_column_type(t)
-  
-  
+
+
 def normalize_default(default):
   if default is None: return None
   if hasattr(default, 'lower'):
@@ -116,7 +368,7 @@ def normalize_default(default):
     default = default.split('::')[0]
     default = default.strip("'")
   return default
-  
+
 def can_convert(type1, type2):
   if type1=='array': return False
   return True
@@ -127,15 +379,15 @@ def are_data_types_equal(db, type_a, type_b):
   if is_mysql(db) and type_a=='bool' and type_b=='tinyint': return True
   if is_postgres(db) and type_a=='char' and type_b=='character': return True
   return False
-  
+
 def column_def_changed(db, a, b):
   # b is the defined column
   return (
-    a.null!=b.null or 
-    not are_data_types_equal(db, a.data_type, b.data_type) or 
-    a.max_length!=b.max_length or 
-    (b.precision is not None and a.precision!=b.precision) or 
-    (b.scale is not None and a.scale!=b.scale) or 
+    a.null!=b.null or
+    not are_data_types_equal(db, a.data_type, b.data_type) or
+    (b.max_length is not None and a.max_length!=b.max_length) or
+    (b.precision is not None and a.precision!=b.precision) or
+    (b.scale is not None and a.scale!=b.scale) or
     a.primary_key!=b.primary_key or
     (DIFF_DEFAULTS and normalize_default(a.default)!=normalize_default(b.default))
   )
@@ -154,12 +406,12 @@ def get_columns_by_table(db, schema='public'):
       schema_check = 'c.table_schema=%s'
       params = [schema]
     sql = '''
-        select 
-          c.column_name, 
-          c.data_type, 
-          c.is_nullable='YES' as is_nullable, 
-          coalesce(tc.constraint_type='PRIMARY KEY',false) as primary_key, 
-          c.table_name, 
+        select
+          c.column_name,
+          c.data_type,
+          c.is_nullable='YES' as is_nullable,
+          coalesce(tc.constraint_type='PRIMARY KEY',false) as primary_key,
+          c.table_name,
           c.column_default,
           c.character_maximum_length as max_length,
           c.numeric_precision,
@@ -186,7 +438,7 @@ def get_columns_by_table(db, schema='public'):
   return columns_by_table
 
 ForeignKeyMetadata = collections.namedtuple('ForeignKeyMetadata', ('column', 'dest_table', 'dest_column', 'table', 'name'))
-    
+
 def get_foreign_keys_by_table(db, schema='public'):
   fks_by_table = collections.defaultdict(list)
   if is_postgres(db):
@@ -254,21 +506,20 @@ def get_indexes_by_table(db, table, schema='public'):
   else:
     return db.get_indexes(table, schema=schema)
 
-def calc_column_changes(db, migrator, etn, ntn, existing_columns, defined_fields, existing_fks):
-  qc = db.compiler()
-  defined_fields_by_column_name = {unicode(f.db_column):f for f in defined_fields}
+def calc_column_changes(db, migrator, etn, ntn, existing_columns, defined_fields, existing_fks_by_column):
+  defined_fields_by_column_name = {unicode(_column_name(f)):f for f in defined_fields}
   defined_columns = [ColumnMetadata(
-    unicode(f.db_column),
-    normalize_field_type(f, qc),
+    unicode(_column_name(f)),
+    normalize_column_type(_field_type(f)),
     f.null,
     f.primary_key,
     unicode(ntn),
     f.default,
-    f.max_length if hasattr(f,'max_length') else None,
-    f.max_digits if hasattr(f,'max_digits') else None,
-    f.decimal_places if hasattr(f,'decimal_places') else None,
+    f.max_length if hasattr(f, 'max_length') else None,
+    f.max_digits if hasattr(f, 'max_digits') else None,
+    f.decimal_places if hasattr(f, 'decimal_places') else None,
   ) for f in defined_fields if isinstance(f, pw.Field)]
-  
+
   existing_cols_by_name = {c.name:c for c in existing_columns}
   defined_cols_by_name = {c.name:c for c in defined_columns}
   existing_col_names = set(existing_cols_by_name.keys())
@@ -287,11 +538,11 @@ def calc_column_changes(db, migrator, etn, ntn, existing_columns, defined_fields
             rename_cols[ec.name] = sc.name
             new_cols.discard(cn)
             delete_cols.discard(aka)
-  
+
   alter_statements = []
   renames_new_to_old = {v:k for k,v in rename_cols.items()}
   not_new_columns = defined_col_names - new_cols
-  
+
   # look for column metadata changes
   for col_name in not_new_columns:
     existing_col = existing_cols_by_name[renames_new_to_old.get(col_name, col_name)]
@@ -299,15 +550,20 @@ def calc_column_changes(db, migrator, etn, ntn, existing_columns, defined_fields
     field = defined_fields_by_column_name[defined_col.name]
     if column_def_changed(db, existing_col, defined_col):
       len_alter_statements = len(alter_statements)
+
+      different_type = existing_col.data_type != defined_col.data_type
+      different_length = defined_col.max_length is not None and existing_col.max_length != defined_col.max_length
+      different_precision = defined_col.precision is not None and existing_col.precision != defined_col.precision
+      different_scale = defined_col.scale is not None and existing_col.scale != defined_col.scale
+
+      should_cast = different_type and can_convert(existing_col.data_type, defined_col.data_type)
+      should_recast = not different_type and (different_length or different_precision or different_scale)
+
       if existing_col.null and not defined_col.null:
-        alter_statements += add_not_null(db, migrator, ntn, field, defined_col.name)
+        alter_statements += add_not_null(db, migrator, ntn, defined_col.name, field)
       if not existing_col.null and defined_col.null:
-        op = migrator.drop_not_null(ntn, defined_col.name, generate=True)
-        alter_statements.append(qc.parse_node(op))
-      if existing_col.data_type != defined_col.data_type and can_convert(existing_col.data_type, defined_col.data_type):
-        stmts = change_column_type(db, migrator, ntn, defined_col.name, field)
-        alter_statements += stmts
-      if existing_col.data_type==defined_col.data_type and (existing_col.max_length!=defined_col.max_length or (defined_col.precision is not None and existing_col.precision!=defined_col.precision) or (defined_col.scale is not None and existing_col.scale!=defined_col.scale)):
+        alter_statements += drop_not_null(migrator, ntn, defined_col)
+      if should_cast or should_recast:
         stmts = change_column_type(db, migrator, ntn, defined_col.name, field)
         alter_statements += stmts
       if DIFF_DEFAULTS:
@@ -323,74 +579,44 @@ def calc_column_changes(db, migrator, etn, ntn, existing_columns, defined_fields
           pass
         else:
           raise Exception("In table %s I don't know how to change %s into %s" % (repr(ntn), existing_col, defined_col))
-  
+
   # look for fk changes
-  existing_fks_by_column = {fk.column:fk for fk in existing_fks}
   for col_name in not_new_columns:
     existing_column_name = renames_new_to_old.get(col_name, col_name)
     defined_field = defined_fields_by_column_name[col_name]
     existing_fk = existing_fks_by_column.get(existing_column_name)
-    if isinstance(defined_field, pw.ForeignKeyField) and not existing_fk and not (hasattr(defined_field,'fake') and defined_field.fake):
-      op = qc._create_foreign_key(defined_field.model_class, defined_field)
-      alter_statements.append(qc.parse_node(op))
-    if not isinstance(defined_field, pw.ForeignKeyField) and existing_fk:
+    foreign_key = _is_foreign_key(defined_field)
+    if foreign_key and not existing_fk and not (hasattr(defined_field, 'fake') and defined_field.fake):
+      alter_statements += create_foreign_key(defined_field)
+    if not foreign_key and existing_fk:
       alter_statements += drop_foreign_key(db, migrator, ntn, existing_fk.name)
-        
-
   return new_cols, delete_cols, rename_cols, alter_statements
 
-def drop_foreign_key(db, migrator, table_name, fk_name):
-  drop_stmt = 'drop foreign key' if is_mysql(db) else 'DROP CONSTRAINT'
-  op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL(drop_stmt), pw.Entity(fk_name))
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
-
-def drop_default(db, migrator, table_name, column_name, field):
-  op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER COLUMN'), pw.Entity(column_name), pw.SQL('DROP DEFAULT'))
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
-
-def set_default(db, migrator, table_name, column_name, field):
-  default = field.default
-  if callable(default): default = default()
-  param = pw.Param(field.db_value(default))
-  op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER COLUMN'), pw.Entity(column_name), pw.SQL('SET DEFAULT'), param)
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
-
-def alter_add_column(db, migrator, ntn, column_name, field):
-  qc = db.compiler()
-  operation = migrator.alter_add_column(ntn, column_name, field, generate=True)
-  to_run = [qc.parse_node(operation)]
-  if is_mysql(db) and isinstance(field, pw.ForeignKeyField):
-    op = qc._create_foreign_key(field.model_class, field)
-    to_run.append(qc.parse_node(op))
-  return to_run
 
 def calc_changes(db, ignore_tables=None):
   migrator = None # expose eventually?
   if migrator is None:
     migrator = auto_detect_migrator(db)
-    
+
   existing_tables = [unicode(t) for t in db.get_tables()]
   existing_indexes = {table:get_indexes_by_table(db, table) for table in existing_tables}
   existing_columns_by_table = get_columns_by_table(db)
   foreign_keys_by_table = get_foreign_keys_by_table(db)
 
-  table_names_to_models = {cls._meta.db_table:cls for cls in all_models.keys()}
+  table_names_to_models = {_table_name(cls): cls for cls in all_models.keys()}
 
-  qc = db.compiler()
   to_run = []
 
   table_adds, add_fks, table_deletes, table_renames = calc_table_changes(existing_tables, ignore_tables=ignore_tables)
-  table_renamed_from = {v:k for k,v in table_renames.items()}
-  to_run += [qc.create_table(table_names_to_models[tbl]) for tbl in table_adds]
+  table_renamed_from = {v: k for k, v in table_renames.items()}
+  for tbl in table_adds:
+    to_run += create_table(table_names_to_models[tbl])
   for field in add_fks:
     if hasattr(field, '__pwdbev__not_deferred') and field.__pwdbev__not_deferred:
       field.deferred = False
-    op = qc._create_foreign_key(field.model_class, field)
-    to_run.append(qc.parse_node(op))
-  for k,v in table_renames.items():
-    ops = migrator.rename_table(k,v, generate=True)
-    if not hasattr(ops, '__iter__'): ops = [ops] # sometimes pw return arrays, sometimes not
-    to_run += [qc.parse_node(op) for op in ops]
+    to_run += create_foreign_key(field)
+  for k, v in table_renames.items():
+    to_run += rename_table(migrator, k, v)
 
 
   rename_cols_by_table = {}
@@ -401,8 +627,9 @@ def calc_changes(db, ignore_tables=None):
     model = table_names_to_models.get(ntn)
     if not model: continue
     defined_fields = model._meta.sorted_fields
-    defined_column_name_to_field = {unicode(f.db_column):f for f in defined_fields}
-    adds, deletes, renames, alter_statements = calc_column_changes(db, migrator, etn, ntn, ecols, defined_fields, foreign_keys_by_table[etn])
+    defined_column_name_to_field = {unicode(_column_name(f)):f for f in defined_fields}
+    existing_fks_by_column = {fk.column:fk for fk in foreign_keys_by_table[etn]}
+    adds, deletes, renames, alter_statements = calc_column_changes(db, migrator, etn, ntn, ecols, defined_fields, existing_fks_by_column)
     for column_name in adds:
       field = defined_column_name_to_field[column_name]
       to_run += alter_add_column(db, migrator, ntn, column_name, field)
@@ -410,13 +637,15 @@ def calc_changes(db, ignore_tables=None):
         # alter_add_column strips null constraints
         # add them back after setting any defaults
         if field.default is not None:
-          operation = migrator.apply_default(ntn, column_name, field, generate=True)
-          to_run.append(qc.parse_node(operation))
+          to_run += set_default(migrator, ntn, column_name, field, generate=True)
         else:
           to_run.append(('-- adding a not null column without a default will fail if the table is not empty',[]))
-        to_run += add_not_null(db, migrator, ntn, field, column_name)
-          
+        to_run += add_not_null(db, migrator, ntn, column_name, field)
+
     for column_name in deletes:
+      fk = existing_fks_by_column.get(column_name)
+      if fk:
+        to_run += drop_foreign_key(db, migrator, ntn, fk.name)
       to_run += drop_column(db, migrator, ntn, column_name)
     for ocn, ncn in renames.items():
       field = defined_column_name_to_field[ncn]
@@ -424,83 +653,19 @@ def calc_changes(db, ignore_tables=None):
     to_run += alter_statements
     rename_cols_by_table[ntn] = renames
     deleted_cols_by_table[ntn] = deletes
-  
+
   for ntn, model in table_names_to_models.items():
     etn = table_renamed_from.get(ntn, ntn)
     deletes = deleted_cols_by_table.get(ntn,set())
     existing_indexes_for_table = [i for i in existing_indexes.get(etn, []) if not any([(c in deletes) for c in i.columns])]
     to_run += calc_index_changes(db, migrator, existing_indexes_for_table, model, rename_cols_by_table.get(ntn, {}))
-  
+
   '''
   to_run += calc_perms_changes($schema_tables, noop) unless $check_perms_for.empty?
   '''
-
-  
-  
-  to_run += [qc.parse_node(pw.Clause(pw.SQL('DROP TABLE'), pw.Entity(tbl))) for tbl in table_deletes]
+  for tbl in table_deletes:
+    to_run += drop_table(migrator, tbl)
   return to_run
-
-def rename_column(db, migrator, ntn, ocn, ncn, field):
-  qc = db.compiler()
-  if is_mysql(db):
-    junk = pw.Clause(
-      pw.SQL('ALTER TABLE'), pw.Entity(ntn), pw.SQL('CHANGE'), pw.Entity(ocn), qc.field_definition(field)
-    )
-  else:
-    junk = migrator.rename_column(ntn, ocn, ncn, generate=True)
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk)
-
-def normalize_op_to_clause(db, migrator, op):
-  if isinstance(op, pw.Clause): return op
-  playhouse.migrate
-  kwargs = op.kwargs.copy()
-  kwargs['generate'] = True
-  ret = getattr(migrator, op.method)(*op.args, **kwargs)
-  return ret
-
-def normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk):
-  # sometimes a clause, sometimes an operation, sometimes a list mixed with clauses and operations
-  # turn it into a list of (sql,params) tuples
-  if not hasattr(junk, '__iter__'):
-    junk = [junk]
-  junk = [normalize_op_to_clause(db, migrator, o) for o in junk]
-  qc = db.compiler()
-  junk = [qc.parse_node(clause) for clause in junk]
-  return junk
-
-def drop_column(db, migrator, ntn, column_name):
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, migrator.drop_column(ntn, column_name, generate=True, cascade=False))
-  
-def change_column_type(db, migrator, table_name, column_name, field):
-  qc = db.compiler()
-  column_type = qc.get_column_type(field.get_db_field())
-  if is_postgres(db):
-    op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('ALTER'), field.as_entity(), pw.SQL('TYPE'), field.__ddl_column__(column_type))
-  elif is_mysql(db):
-    op = pw.Clause(*[pw.SQL('ALTER TABLE'), pw.Entity(table_name), pw.SQL('MODIFY')] + field.__ddl__(column_type))
-  else:
-    raise Exception('how do i change a column type for %s?' % db)
-  return normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, op)
-  
-def add_not_null(db, migrator, table, field, column_name):
-  qc = db.compiler()
-  cmds = []
-  if field.default is not None:
-    # if default is a function, turn it into a value
-    # this won't work on columns requiring uniquiness, like UUIDs
-    # as all columns will share the same called value
-    default = field.default() if hasattr(field.default, '__call__') else field.default
-    op = pw.Clause(pw.SQL('UPDATE'), pw.Entity(table), pw.SQL('SET'), field.as_entity(), pw.SQL('='), default, pw.SQL('WHERE'), field.as_entity(), pw.SQL('IS NULL'))
-    cmds.append(qc.parse_node(op))
-  if is_postgres(db) or is_sqlite(db):
-    junk = migrator.add_not_null(table, column_name, generate=True)
-    cmds += normalize_whatever_junk_peewee_migrations_gives_you(db, migrator, junk)
-    return cmds
-  elif is_mysql(db):
-    op = pw.Clause(pw.SQL('ALTER TABLE'), pw.Entity(table), pw.SQL('MODIFY'), qc.field_definition(field))
-    cmds.append(qc.parse_node(op))
-    return cmds
-  raise Exception('how do i add a not null for %s?' % db)
 
 def indexes_are_same(i1, i2):
   return unicode(i1.table)==unicode(i2.table) and i1.columns==i2.columns and i1.unique==i2.unique
@@ -508,35 +673,33 @@ def indexes_are_same(i1, i2):
 def normalize_indexes(indexes):
   return [(unicode(idx.table), tuple(unicode(c) for c in idx.columns), idx.unique) for idx in indexes]
 
-  
+
 def calc_index_changes(db, migrator, existing_indexes, model, renamed_cols):
-  qc = db.compiler()  
   to_run = []
   fields = list(model._meta.sorted_fields)
-  fields_by_column_name = {f.db_column:f for f in fields}
-  pk_cols = set([unicode(f.db_column) for f in fields if f.primary_key])
+  fields_by_column_name = {_column_name(f):f for f in fields}
+  pk_cols = set([unicode(_column_name(f)) for f in fields if f.primary_key])
   existing_indexes = [i for i in existing_indexes if not all([(unicode(c) in pk_cols) for c in i.columns])]
   normalized_existing_indexes = normalize_indexes(existing_indexes)
   existing_indexes_by_normalized_existing_indexes = dict(zip(normalized_existing_indexes, existing_indexes))
   normalized_existing_indexes = set(normalized_existing_indexes)
-  defined_indexes = [pw.IndexMetadata('', '', [f.db_column], f.unique, model._meta.db_table) for f in model._fields_to_index()]
+  defined_indexes = indexes_on_model(model)
   for fields, unique in model._meta.indexes:
     try:
-      columns = [model._meta.fields[fname].db_column for fname in fields]
+      columns = [_column_name(model._meta.fields[fname]) for fname in fields]
     except KeyError as e:
       raise Exception("Index %s on %s references field %s in a multi-column index, but that field doesn't exist. (Be sure to use the field name, not the db_column name, when specifying a multi-column index.)" % ((fields, unique), model.__name__, repr(e.message)))
-    defined_indexes.append(pw.IndexMetadata('', '', columns, unique, model._meta.db_table))
+    defined_indexes.append(pw.IndexMetadata('', '', columns, unique, _table_name(model)))
   normalized_defined_indexes = set(normalize_indexes(defined_indexes))
   to_add = normalized_defined_indexes - normalized_existing_indexes
   to_del = normalized_existing_indexes - normalized_defined_indexes
   for index in to_del:
     index = existing_indexes_by_normalized_existing_indexes[index]
-    op = migrator.drop_index(model._meta.db_table, index.name, generate=True)
-    to_run.append(qc.parse_node(op))
+    to_run += drop_index(migrator, model, index)
   for index in to_add:
-    to_run.append(qc.create_index(model, [fields_by_column_name[col] for col in index[1]], index[2]))
+    to_run += create_index(model, [fields_by_column_name[col] for col in index[1]], index[2])
   return to_run
-  
+
 def evolve(db, interactive=True, ignore_tables=None):
   if interactive:
     print((colorama.Style.BRIGHT + colorama.Fore.RED + 'Making updates to database: {}'.format(db.database) + colorama.Style.RESET_ALL))
@@ -545,11 +708,10 @@ def evolve(db, interactive=True, ignore_tables=None):
     if interactive:
       print('Nothing to do... Your database is up to date!')
     return
-  
+
   commit = True
   if interactive:
     commit = _confirm(db, to_run)
-
   _execute(db, to_run, interactive=interactive, commit=commit)
 
 
@@ -564,8 +726,8 @@ def _execute(db, to_run, interactive=True, commit=True):
       if interactive:
         print()
         print(
-          (colorama.Style.BRIGHT + 'SUCCESS!' + colorama.Style.RESET_ALL) if commit else 'TEST PASSED - ROLLING BACK', 
-          colorama.Style.DIM + '-', 
+          (colorama.Style.BRIGHT + 'SUCCESS!' + colorama.Style.RESET_ALL) if commit else 'TEST PASSED - ROLLING BACK',
+          colorama.Style.DIM + '-',
           'https://github.com/keredson/peewee-db-evolve' + colorama.Style.RESET_ALL
         )
         print()
@@ -601,7 +763,7 @@ def print_sql(sql):
     for pattern in patterns:
       sql = sql.replace(pattern, color + pattern + colorama.Style.RESET_ALL)
   print(sql)
-  
+
 
 def _confirm(db, to_run):
   print()
@@ -626,7 +788,7 @@ def _confirm(db, to_run):
     time.sleep(1)
   print()
   return response=='yes'
-  
+
 
 
 
@@ -635,7 +797,7 @@ ignore_tables = set()
 
 def register(model):
   if hasattr(model._meta, 'evolve') and not model._meta.evolve:
-    ignore_tables.add(model._meta.db_table)
+    ignore_tables.add(_table_name(model))
   else:
     all_models[model] = []
 
@@ -647,7 +809,8 @@ def clear():
   ignore_tables.clear()
 
 def _add_model_hook():
-  init = pw.BaseModel.__init__
+  ModelBase = pw.BaseModel if hasattr(pw, 'BaseModel') else pw.ModelBase
+  init = ModelBase.__init__
   def _init(*args, **kwargs):
     cls = args[0]
     fields = args[3]
@@ -655,7 +818,7 @@ def _add_model_hook():
       del fields['__module__']
     register(cls)
     init(*args, **kwargs)
-  pw.BaseModel.__init__ = _init
+  ModelBase.__init__ = _init
 
 def _add_field_hook():
   init = pw.Field.__init__

--- a/test.py
+++ b/test.py
@@ -8,6 +8,19 @@ import peeweedbevolve
 # turn on for debugging individual test cases
 INTERACTIVE = False
 
+PW3 = not hasattr(pw, 'Clause')
+def foreign_key(model, **kwargs):
+  if PW3:
+    return pw.ForeignKeyField(model=model, **kwargs)
+  else:
+    return pw.ForeignKeyField(rel_model=model, **kwargs)
+
+if PW3:
+  DeferredForeignKey = pw.DeferredForeignKey
+else:
+  def DeferredForeignKey(*args):
+    pw.ForeignKeyField(pw.DeferredRelation(*args))
+
 
 
 class PostgreSQL(unittest.TestCase):
@@ -25,7 +38,7 @@ class PostgreSQL(unittest.TestCase):
   def tearDown(self):
     self.db.close()
     os.system('dropdb peeweedbevolve_test')
-  
+
   def evolve_and_check_noop(self):
     self.db.evolve(interactive=INTERACTIVE)
     self.check_noop()
@@ -61,7 +74,7 @@ class PostgreSQL(unittest.TestCase):
         database = self.db
     class SomeModel2(pw.Model):
       some_field2 = pw.CharField(null=True)
-      some_model = pw.ForeignKeyField(rel_model=SomeModel)
+      some_model = foreign_key(SomeModel)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
@@ -78,7 +91,7 @@ class PostgreSQL(unittest.TestCase):
     self.evolve_and_check_noop()
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
-      owner = pw.ForeignKeyField(rel_model=Person, null=False)
+      owner = foreign_key(Person, null=False)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
@@ -90,7 +103,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
     class Car(pw.Model):
-      owner = pw.ForeignKeyField(rel_model=Person, null=False)
+      owner = foreign_key(Person, null=False)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
@@ -115,7 +128,7 @@ class PostgreSQL(unittest.TestCase):
     car = Car.create(owner_id=person.id)
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
-      owner = pw.ForeignKeyField(rel_model=Person, null=False)
+      owner = foreign_key(Person, null=False)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
@@ -127,7 +140,7 @@ class PostgreSQL(unittest.TestCase):
       class Meta:
         database = self.db
     class Car(pw.Model):
-      owner = pw.ForeignKeyField(rel_model=Person, null=False)
+      owner = foreign_key(Person, null=False)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
@@ -337,7 +350,7 @@ class PostgreSQL(unittest.TestCase):
     self.assertEqual(SomeOtherModel.select().first().some_other_field, 'woot')
     with self.db.atomic() as txn:
       self.assertRaises(Exception, lambda: SomeOtherModel.create(some_other_field=None))
-  
+
   def test_add_index(self):
     self.test_create_table()
     peeweedbevolve.clear()
@@ -488,14 +501,14 @@ class PostgreSQL(unittest.TestCase):
     car = Car.create(owner_id=-1)
     peeweedbevolve.unregister(Car)
     class Car(pw.Model):
-      owner = pw.ForeignKeyField(rel_model=Person, null=False, fake=True)
+      owner = foreign_key(Person, null=False, fake=True)
       class Meta:
         database = self.db
     self.evolve_and_check_noop()
     person = Person.create()
     car = Car.create(owner=-2)
     self.assertEqual(Car.select().count(), 2)
-    
+
   def test_add_column_default(self):
     self.test_create_table()
     peeweedbevolve.clear()
@@ -560,7 +573,7 @@ class PostgreSQL(unittest.TestCase):
 
   def test_circular_deps(self):
     class SomeModel(pw.Model):
-      some_model2 = pw.ForeignKeyField(pw.DeferredRelation('SomeModel2'))
+      some_model2 = DeferredForeignKey('SomeModel2')
       class Meta:
         database = self.db
     class SomeModel2(pw.Model):
@@ -756,5 +769,5 @@ class MySQL(PostgreSQL):
 
 
 if __name__ == "__main__":
-   unittest.main()
+   unittest.main(failfast=False)
 


### PR DESCRIPTION
This PR covers changes needed to get the tests passing on Peewee 3.7. Rather than take the approach in the other PR around creating a fake compiler object I have just centralised the calls that require a compiler. This means that when the maintainers decide to drop support for Peewee 2, it should just be a delete operation - rather than cleaning up a concept that no longer exists in Peewee.

I have tested on Peewee 2.10 and 3.7 on both Python 3.7 and 2.7, but I can test on additional versions if required.

This PR should fix #26 and #30