### PR TITLE
Added always_confirm_no option

### DIFF
--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -670,6 +670,9 @@ def calc_changes(db, ignore_tables=None):
     deleted_cols_by_table[ntn] = deletes
 
   for ntn, model in table_names_to_models.items():
+    # if ignoring this table, skip index manipulation
+    if model._meta.table_name in ignore_tables:
+      continue
     etn = table_renamed_from.get(ntn, ntn)
     deletes = deleted_cols_by_table.get(ntn,set())
     existing_indexes_for_table = [i for i in existing_indexes.get(etn, []) if not any([(c in deletes) for c in i.columns])]

--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -715,7 +715,7 @@ def calc_index_changes(db, migrator, existing_indexes, model, renamed_cols):
     to_run += create_index(model, [fields_by_column_name[col] for col in index[1]], index[2])
   return to_run
 
-def evolve(db, interactive=True, ignore_tables=None):
+def evolve(db, interactive=True, ignore_tables=None, always_confirm_no=False):
   if interactive:
     print((colorama.Style.BRIGHT + colorama.Fore.RED + 'Making updates to database: {}'.format(db.database) + colorama.Style.RESET_ALL))
   to_run = calc_changes(db, ignore_tables=ignore_tables)
@@ -726,7 +726,7 @@ def evolve(db, interactive=True, ignore_tables=None):
 
   commit = True
   if interactive:
-    commit = _confirm(db, to_run)
+    commit = _confirm(db, to_run, always_confirm_no)
   _execute(db, to_run, interactive=interactive, commit=commit)
 
 
@@ -780,7 +780,7 @@ def print_sql(sql):
   print(sql)
 
 
-def _confirm(db, to_run):
+def _confirm(db, to_run, always_confirm_no):
   print()
   print("Your database needs the following %s:" % ('changes' if len(to_run)>1 else 'change'))
   print()
@@ -789,6 +789,9 @@ def _confirm(db, to_run):
     print_sql('  %s; %s' % (sql, params or ''))
   if is_postgres(db): print_sql('\n  COMMIT;')
   print()
+  if always_confirm_no:
+    print("Confirming 'no' to these changes as always_confirm_no is True")
+    sys.exit(1)
   while True:
     print('Do you want to run %s? (%s)' % (('these commands' if len(to_run)>1 else 'this command'), ('type yes, no or test' if is_postgres(db) else 'yes or no')), end=' ')
     response = raw_input().strip().lower()

--- a/peeweedbevolve.py
+++ b/peeweedbevolve.py
@@ -718,10 +718,13 @@ def calc_index_changes(db, migrator, existing_indexes, model, renamed_cols):
     to_run += create_index(model, [fields_by_column_name[col] for col in index[1]], index[2])
   return to_run
 
-def evolve(db, interactive=True, ignore_tables=None, always_confirm_no=False):
+def evolve(db, interactive=True, ignore_tables=None, always_confirm_no=False, testing=False):
   if interactive:
     print((colorama.Style.BRIGHT + colorama.Fore.RED + 'Making updates to database: {}'.format(db.database) + colorama.Style.RESET_ALL))
   to_run = calc_changes(db, ignore_tables=ignore_tables)
+  # in testing mode, return the sql to run so that it can be checked for correctness
+  if testing:
+    return to_run
   if not to_run:
     if interactive:
       print('Nothing to do... Your database is up to date!')


### PR DESCRIPTION
I could have missed something, but I didn't see an option to, without manual intervention, confirm 'no' to some required migration. 

We have a situation where evolve is run remotely and we wanted to automatically confirm 'no' if a migration was required to allow the program to not wait forever. Setting `interactive=False` would always enact the migration.

Is there another way of doing this currently?

The only thing that doesn't quite gel with this addition is that to get the bright red output:

> Making updates to database: dbname

interactive needs to be True with a call like `db.evolve(interactive=True, always_confirm_no=True)`

and this seems weird if you're using this option for automated operation. Was there a reason you only output "Making updates to database: dbname" if interactive is True?